### PR TITLE
Missing paragraph tag fix

### DIFF
--- a/src/GithubUserData/template.html
+++ b/src/GithubUserData/template.html
@@ -1,5 +1,5 @@
 <div v-if="data">
   <h4>{{ data.name }}</h4>
   <p>{{ data.company }}</p>
-  <p>Number of repos: {{ data.public_repos }}
+  <p>Number of repos: {{ data.public_repos }}</p>
 </div>


### PR DESCRIPTION
Fix for build error:
```
Vue template syntax error:
  tag <p> has no matching end tag.